### PR TITLE
Update Makevars.win

### DIFF
--- a/src/Makevars.win
+++ b/src/Makevars.win
@@ -1,7 +1,7 @@
 TARGET = $(subst 64,x86_64,$(subst 32,i686,$(WIN)))-pc-windows-gnu
 LIBDIR = ./rust/target/$(TARGET)/release
 STATLIB = $(LIBDIR)/libmsfastar.a
-PKG_LIBS = -L$(LIBDIR) -lmsfastar -lws2_32 -ladvapi32 -luserenv
+PKG_LIBS = -L$(LIBDIR) -lmsfastar -lws2_32 -ladvapi32 -luserenv -lntdll -lbcrypt
 
 all: C_clean
 


### PR DESCRIPTION
Add requisite libraries for successful Windows compilation. Building the package in Windows [will fail](https://yutani.rbind.io/post/rust-1.70-and-build-failure-on-windows/) for Rust 1.7.0 or greater due to the requirement for these libraries. See the updated extendr template [here](https://github.com/extendr/extendr/blob/619ea38e7213e9c974dba3cfd7c0c1a51c6d1902/tests/extendrtests/src/Makevars.win#L6). 